### PR TITLE
feat: define TypeScript types for game engine (#13)

### DIFF
--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -1,0 +1,101 @@
+/**
+ * Tipos para las filas de Supabase (Database layer).
+ * Placeholder: se actualizará cuando se integren las migraciones reales.
+ *
+ * Convención de nombres:
+ *  - `Db*`      → fila tal como viene de la base de datos (snake_case)
+ *  - `Db*Insert` → campos necesarios para crear un registro
+ *  - `Db*Update` → campos opcionales para actualizar un registro
+ */
+
+// ─── question_sets ────────────────────────────────────────────────────────────
+
+export interface DbQuestionSet {
+  id: string
+  title: string
+  description: string | null
+  user_id: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface DbQuestionSetInsert {
+  title: string
+  description?: string | null
+  user_id?: string | null
+}
+
+export interface DbQuestionSetUpdate {
+  title?: string
+  description?: string | null
+  updated_at?: string
+}
+
+// ─── questions ────────────────────────────────────────────────────────────────
+
+export interface DbQuestion {
+  id: string
+  question_set_id: string
+  text: string
+  created_at: string
+}
+
+export interface DbQuestionInsert {
+  question_set_id: string
+  text: string
+}
+
+export interface DbQuestionUpdate {
+  text?: string
+}
+
+// ─── answers ─────────────────────────────────────────────────────────────────
+
+export interface DbAnswer {
+  id: string
+  question_id: string
+  text: string
+  points: number
+  order_index: number
+}
+
+export interface DbAnswerInsert {
+  question_id: string
+  text: string
+  points: number
+  order_index: number
+}
+
+export interface DbAnswerUpdate {
+  text?: string
+  points?: number
+  order_index?: number
+}
+
+// ─── games ────────────────────────────────────────────────────────────────────
+
+export interface DbGame {
+  id: string
+  user_id: string | null
+  question_set_id: string
+  team1_name: string
+  team1_score: number
+  team2_name: string
+  team2_score: number
+  winner: 'team1' | 'team2' | 'draw'
+  total_rounds: number
+  completed_at: string
+  created_at: string
+}
+
+export interface DbGameInsert {
+  user_id?: string | null
+  question_set_id: string
+  team1_name: string
+  team1_score: number
+  team2_name: string
+  team2_score: number
+  winner: 'team1' | 'team2' | 'draw'
+  total_rounds: number
+  completed_at: string
+}

--- a/types/game.types.ts
+++ b/types/game.types.ts
@@ -1,0 +1,106 @@
+/**
+ * Tipos TypeScript para el motor del juego "La Respuesta más Popular".
+ * Todos los tipos son inmutables por convención — los reducers siempre
+ * devuelven nuevas instancias.
+ */
+
+import type { Question } from './question.types'
+
+// ─── Tipos primitivos ───────────────────────────────────────────────────────
+
+/** Identificador de equipo */
+export type Team = 'team1' | 'team2'
+
+/**
+ * Fases del juego:
+ * - `setup`    → configuración antes de iniciar
+ * - `playing`  → equipo activo respondiendo
+ * - `stealing` → equipo contrario intenta robar puntos
+ * - `finished` → ronda o juego terminado
+ */
+export type GamePhase = 'setup' | 'playing' | 'stealing' | 'finished'
+
+// ─── Interfaces de datos ────────────────────────────────────────────────────
+
+/** Datos de un equipo en el estado del juego */
+export interface TeamData {
+  /** Nombre visible del equipo */
+  name: string
+  /** Puntuación acumulada */
+  score: number
+}
+
+/**
+ * Estado completo del juego en un momento dado.
+ * Es la fuente de verdad para toda la lógica del game engine y el contexto.
+ */
+export interface GameState {
+  /** UUID único de la partida */
+  id: string
+  /** Fase actual del juego */
+  phase: GamePhase
+  /** Índice (0-based) de la pregunta activa dentro de `questions` */
+  currentQuestionIndex: number
+  /** Número de ronda actual (1-based) */
+  currentRound: number
+  /** Número total de rondas configuradas */
+  totalRounds: number
+  /** Datos del equipo 1 */
+  team1: TeamData
+  /** Datos del equipo 2 */
+  team2: TeamData
+  /** Equipo que tiene el turno activo */
+  activeTeam: Team
+  /** Número de fallos en la ronda actual (máx. 3) */
+  strikes: number
+  /** Índices (0-based) de las respuestas ya reveladas en la pregunta actual */
+  revealedAnswers: number[]
+  /** Puntos acumulados en la ronda actual (antes de asignarse a un equipo) */
+  roundPoints: number
+  /** Multiplicador de puntos aplicado a la ronda actual */
+  multiplier: number
+  /** Lista de preguntas de la partida */
+  questions: Question[]
+}
+
+/**
+ * Configuración inicial para crear una nueva partida.
+ * Se usa antes de construir el primer `GameState`.
+ */
+export interface GameConfig {
+  /** Nombre del equipo 1 */
+  team1Name: string
+  /** Nombre del equipo 2 */
+  team2Name: string
+  /** Número total de rondas */
+  totalRounds: number
+  /** Preguntas que se jugarán */
+  questions: Question[]
+}
+
+/** Resultado de una partida completada, listo para persistir */
+export interface GameResult {
+  id: string
+  team1: TeamData
+  team2: TeamData
+  winner: Team | 'draw'
+  totalRounds: number
+  completedAt: string
+  /** ID del set de preguntas usado */
+  questionSetId: string
+}
+
+// ─── Acciones del reducer ───────────────────────────────────────────────────
+
+/**
+ * Union type de todas las acciones posibles del game context.
+ * Cada acción corresponde a una transición de estado en el reducer.
+ */
+export type GameAction =
+  | { type: 'REVEAL_ANSWER'; payload: number }
+  | { type: 'ADD_STRIKE' }
+  | { type: 'SWITCH_TEAM' }
+  | { type: 'ATTEMPT_STEAL'; payload: number }
+  | { type: 'NEXT_QUESTION' }
+  | { type: 'END_GAME' }
+  | { type: 'RESET_GAME'; payload?: GameConfig }

--- a/types/question.types.ts
+++ b/types/question.types.ts
@@ -1,0 +1,62 @@
+/**
+ * Tipos TypeScript para preguntas, respuestas y sets de preguntas.
+ * Estos tipos son compartidos entre el game engine y las vistas de gestión.
+ */
+
+// ─── Respuesta individual ────────────────────────────────────────────────────
+
+/** Una respuesta dentro de una pregunta */
+export interface Answer {
+  /** UUID de la respuesta */
+  id: string
+  /** Texto de la respuesta */
+  text: string
+  /** Puntos que otorga esta respuesta */
+  points: number
+  /** Posición en el ranking (1 = la más popular) */
+  orderIndex: number
+}
+
+// ─── Pregunta ────────────────────────────────────────────────────────────────
+
+/** Una pregunta con sus respuestas encuestas */
+export interface Question {
+  /** UUID de la pregunta */
+  id: string
+  /** Texto de la pregunta que se lee en voz alta */
+  text: string
+  /** Lista de respuestas ordenadas por `orderIndex` */
+  answers: Answer[]
+}
+
+// ─── Set de preguntas ────────────────────────────────────────────────────────
+
+/** Colección de preguntas agrupadas bajo un tema o episodio */
+export interface QuestionSet {
+  /** UUID del set */
+  id: string
+  /** Título descriptivo del set */
+  title: string
+  /** Descripción opcional */
+  description?: string
+  /** Preguntas que contiene el set */
+  questions: Question[]
+  /** ID del usuario propietario (null si es demo/público) */
+  userId: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+/**
+ * Vista resumida de un set de preguntas, sin cargar todas las respuestas.
+ * Útil para listar sets en el selector.
+ */
+export interface QuestionSetSummary {
+  id: string
+  title: string
+  description?: string
+  questionCount: number
+  userId: string | null
+  createdAt: string
+  updatedAt: string
+}


### PR DESCRIPTION
## Summary

Defines all TypeScript types needed by the game engine, context, and database layer as described in #13.

## Changes

### `types/game.types.ts`
- `Team` — `'team1' | 'team2'` literal union
- `GamePhase` — `'setup' | 'playing' | 'stealing' | 'finished'`
- `TeamData` — `{ name, score }`
- `GameState` — complete game state (id, phase, round, teams, strikes, revealedAnswers, multiplier, questions)
- `GameConfig` — input shape for starting a new game
- `GameResult` — shape for saving a completed game
- `GameAction` — union type for all reducer actions (REVEAL_ANSWER, ADD_STRIKE, SWITCH_TEAM, ATTEMPT_STEAL, NEXT_QUESTION, END_GAME, RESET_GAME)

### `types/question.types.ts`
- `Answer` — `{ id, text, points, orderIndex }`
- `Question` — `{ id, text, answers }`
- `QuestionSet` — full set with questions array
- `QuestionSetSummary` — lightweight version for list views

### `types/database.types.ts`
Placeholder Supabase row types (snake_case) with Insert/Update helpers:
- `DbQuestionSet`, `DbQuestion`, `DbAnswer`, `DbGame`

## Testing

- [x] `npx tsc --noEmit` — no errors
- [x] `npm run lint --quiet` — no errors
- [x] Zero `any` types
- [x] All types exported from their respective files
- [x] JSDoc comments on all complex interfaces

## Related Issues

Closes #13
Unblocks #14 (GameEngine), #15 (GameContext), #16 (scoring)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)