### PR TITLE
feat: implement GameControls component (#25)

### DIFF
--- a/components/game/GameControlPanel.tsx
+++ b/components/game/GameControlPanel.tsx
@@ -3,6 +3,7 @@
 import { useGame } from '@/contexts/GameContext'
 
 import { AnswerCard } from '@/components/game/AnswerCard'
+import { GameControls } from '@/components/game/GameControls'
 import { QuestionDisplay } from '@/components/game/QuestionDisplay'
 import { StrikeIndicator } from '@/components/game/StrikeIndicator'
 import { TeamScore } from '@/components/game/TeamScore'
@@ -50,6 +51,10 @@ export function GameControlPanel(): React.ReactElement {
 
   const handleStealFail = (): void => {
     dispatch({ type: 'ATTEMPT_STEAL', payload: -1 })
+  }
+
+  const handleResetGame = (): void => {
+    dispatch({ type: 'RESET_GAME' })
   }
 
   const isSetupOrFinished = state.phase === 'setup' || state.phase === 'finished'
@@ -219,63 +224,26 @@ export function GameControlPanel(): React.ReactElement {
           )}
         </section>
 
-        {/* ── Columna derecha — strikes + acciones ────────────────────────── */}
+        {/* ── Columna derecha — strikes + controles ───────────────────────── */}
         <section className="w-1/4 flex flex-col gap-6">
 
-          {/* Strikes + botón STRIKE */}
+          {/* Marcador de strikes */}
           <div className="bg-game-card border border-warm-border rounded-2xl p-6 flex flex-col items-center">
             <StrikeIndicator strikes={state.strikes} displayMode="control" />
-
-            {/* Botón STRIKE circular */}
-            <button
-              type="button"
-              onClick={handleAddStrike}
-              disabled={state.phase !== 'playing'}
-              aria-label="Agregar strike"
-              className="mt-8 w-full aspect-square max-w-[180px] bg-danger-strike text-white rounded-full flex flex-col items-center justify-center gap-1 border-[10px] border-game-board shadow-2xl hover:brightness-110 active:scale-95 transition-all disabled:opacity-40 disabled:pointer-events-none group"
-            >
-              <span className="material-symbols-outlined text-7xl font-black group-active:scale-125 transition-transform">
-                close
-              </span>
-              <span className="text-sm font-black uppercase tracking-tighter">STRIKE</span>
-            </button>
-
-            {/* Reset strikes / cambiar turno */}
-            <div className="w-full mt-6">
-              <button
-                type="button"
-                onClick={handleSwitchTeam}
-                disabled={isSetupOrFinished}
-                className="w-full py-2 bg-game-card border border-warm-border rounded-lg text-[10px] font-bold text-gray-400 hover:text-white hover:bg-warm-border transition-all flex items-center justify-center gap-2 disabled:opacity-40 disabled:pointer-events-none"
-              >
-                <span className="material-symbols-outlined text-sm">refresh</span>
-                RESET TURNO
-              </button>
-            </div>
           </div>
 
-          {/* Secuencia de juego */}
-          <div className="bg-primary/5 border border-primary/20 p-6 rounded-2xl mt-auto space-y-4">
-            <h4 className="text-center text-[10px] font-bold text-primary uppercase tracking-[0.2em]">
-              Secuencia de Juego
-            </h4>
-            <div className="space-y-3">
-              <button
-                type="button"
-                onClick={handleNextQuestion}
-                disabled={state.phase === 'setup'}
-                className="w-full h-16 bg-primary text-game-board rounded-xl font-black text-lg hover:shadow-[0_0_20px_rgba(219,166,31,0.4)] transition-all flex items-center justify-center gap-3 group px-4 disabled:opacity-40 disabled:pointer-events-none"
-              >
-                <span className="leading-tight">SIGUIENTE PREGUNTA</span>
-                <span className="material-symbols-outlined font-black group-hover:translate-x-1 transition-transform">
-                  arrow_forward
-                </span>
-              </button>
-            </div>
-          </div>
+          {/* Botones de acción — GameControls */}
+          <GameControls
+            onNextQuestion={handleNextQuestion}
+            onAddStrike={handleAddStrike}
+            onSwitchTeam={handleSwitchTeam}
+            onResetGame={handleResetGame}
+            canNextQuestion={!isSetupOrFinished}
+            canAddStrike={state.phase === 'playing'}
+          />
 
           {/* Estado de conexión */}
-          <div className="flex items-center justify-center gap-3 py-2 px-4 bg-game-card/30 rounded-full border border-warm-border/50">
+          <div className="mt-auto flex items-center justify-center gap-3 py-2 px-4 bg-game-card/30 rounded-full border border-warm-border/50">
             <div className="size-2 rounded-full bg-green-500 animate-pulse" />
             <span className="text-[10px] font-bold text-gray-500 uppercase tracking-widest">
               Tablero conectado

--- a/components/game/GameControls.tsx
+++ b/components/game/GameControls.tsx
@@ -1,0 +1,145 @@
+'use client'
+
+import { useState } from 'react'
+
+import { Button } from '@/components/ui/Button'
+import { Modal } from '@/components/ui/Modal'
+
+export interface GameControlsProps {
+  /** Avanzar a la siguiente pregunta */
+  onNextQuestion: () => void
+  /** Agregar un strike manual al equipo activo */
+  onAddStrike: () => void
+  /** Cambiar el equipo con posesión del turno */
+  onSwitchTeam: () => void
+  /** Reiniciar el juego completo (acción destructiva — muestra confirmación) */
+  onResetGame: () => void
+  /** Habilita el botón "Siguiente Pregunta" (false cuando el juego está en setup) */
+  canNextQuestion: boolean
+  /** Habilita el botón "Strike" (true solo en fase `playing`) */
+  canAddStrike: boolean
+  className?: string
+}
+
+/**
+ * Controles de acción del moderador.
+ *
+ * Componente exclusivo de `/play/control` — nunca aparece en el tablero público.
+ * Recibe callbacks ya conectados al `dispatch` del `GameContext`.
+ *
+ * Acciones:
+ * - **Strike** → agrega un fallo al equipo activo
+ * - **Siguiente Pregunta** → avanza la ronda
+ * - **Cambiar Turno** → transfiere posesión al equipo contrario
+ * - **Reiniciar Juego** → resetea el estado (con confirmación modal)
+ */
+export function GameControls({
+  onNextQuestion,
+  onAddStrike,
+  onSwitchTeam,
+  onResetGame,
+  canNextQuestion,
+  canAddStrike,
+  className = '',
+}: GameControlsProps): React.ReactElement {
+  const [showResetConfirm, setShowResetConfirm] = useState(false)
+
+  const handleResetConfirm = (): void => {
+    onResetGame()
+    setShowResetConfirm(false)
+  }
+
+  return (
+    <>
+      <div className={`flex flex-col gap-3 ${className}`}>
+
+        {/* ── Strike ──────────────────────────────────────────────────────── */}
+        <button
+          type="button"
+          onClick={onAddStrike}
+          disabled={!canAddStrike}
+          aria-label="Agregar strike al equipo activo"
+          title={canAddStrike ? 'Agregar strike' : 'Solo disponible en fase de juego'}
+          className="w-full h-14 bg-danger-strike text-white rounded-xl font-black text-base flex items-center justify-center gap-2 hover:brightness-110 active:scale-95 transition-all disabled:opacity-40 disabled:pointer-events-none group"
+        >
+          <span className="material-symbols-outlined text-xl font-black group-active:scale-125 transition-transform">
+            close
+          </span>
+          STRIKE
+        </button>
+
+        {/* ── Siguiente pregunta ───────────────────────────────────────────── */}
+        <button
+          type="button"
+          onClick={onNextQuestion}
+          disabled={!canNextQuestion}
+          aria-label="Avanzar a la siguiente pregunta"
+          title={canNextQuestion ? 'Siguiente pregunta' : 'No disponible en fase de configuración'}
+          className="w-full h-14 bg-primary text-game-board rounded-xl font-black text-sm flex items-center justify-center gap-2 hover:shadow-[0_0_20px_rgba(219,166,31,0.4)] transition-all disabled:opacity-40 disabled:pointer-events-none group"
+        >
+          SIGUIENTE PREGUNTA
+          <span className="material-symbols-outlined font-black group-hover:translate-x-1 transition-transform">
+            arrow_forward
+          </span>
+        </button>
+
+        {/* ── Cambiar turno ────────────────────────────────────────────────── */}
+        <button
+          type="button"
+          onClick={onSwitchTeam}
+          aria-label="Cambiar turno al equipo contrario"
+          title="Transferir posesión al equipo contrario"
+          className="w-full py-2.5 bg-game-card border border-warm-border rounded-lg text-xs font-bold text-gray-400 hover:text-white hover:bg-warm-border transition-all flex items-center justify-center gap-2"
+        >
+          <span className="material-symbols-outlined text-sm">swap_horiz</span>
+          CAMBIAR TURNO
+        </button>
+
+        {/* ── Reiniciar juego ──────────────────────────────────────────────── */}
+        <button
+          type="button"
+          onClick={() => setShowResetConfirm(true)}
+          aria-label="Reiniciar juego completo"
+          title="Reiniciar el juego desde el principio"
+          className="w-full py-2.5 bg-transparent border border-warm-border rounded-lg text-xs font-bold text-gray-500 hover:text-danger-strike hover:border-danger-strike/50 transition-all flex items-center justify-center gap-2"
+        >
+          <span className="material-symbols-outlined text-sm">restart_alt</span>
+          REINICIAR JUEGO
+        </button>
+      </div>
+
+      {/* ── Modal de confirmación de reset ──────────────────────────────────── */}
+      <Modal
+        isOpen={showResetConfirm}
+        onClose={() => setShowResetConfirm(false)}
+        title="Reiniciar Juego"
+        footer={
+          <div className="flex gap-3 w-full justify-end">
+            <Button
+              variant="outline"
+              onClick={() => setShowResetConfirm(false)}
+              ariaLabel="Cancelar reinicio"
+            >
+              Cancelar
+            </Button>
+            <Button
+              variant="danger"
+              onClick={handleResetConfirm}
+              ariaLabel="Confirmar reinicio del juego"
+            >
+              Sí, reiniciar
+            </Button>
+          </div>
+        }
+      >
+        <p className="text-gray-300 text-sm leading-relaxed">
+          ¿Estás seguro que deseas reiniciar el juego? Se perderán todos los puntos
+          y el progreso de la partida actual.
+        </p>
+        <p className="text-gray-500 text-xs mt-2">
+          Esta acción no se puede deshacer.
+        </p>
+      </Modal>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
Implements the \`GameControls\` action panel from issue #25.

## Changes
- \`components/game/GameControls.tsx\` — reusable control buttons component with props interface as per spec: Strike, Siguiente Pregunta, Cambiar Turno, Reiniciar Juego
- Reset confirmation via \`Modal\` component (destructive action guard)
- Disabled states + tooltip hints per button
- \`components/game/GameControlPanel.tsx\` — refactored right column to use \`GameControls\` instead of inline buttons; added \`handleResetGame\` dispatch handler

## Testing
- [x] TypeScript: no errors
- [x] Lint: no errors (pre-existing warnings only)
- [x] Tested at \`/play/control\` — all 4 buttons render correctly
- [x] Strike + Next Question correctly disabled in \`setup\` phase
- [x] Reset confirmation modal opens and closes
- [x] No console errors

## Related Issues
Closes #25

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)