### PR TITLE
feat: auto-save and restore game state via localStorage (#29)

### DIFF
--- a/app/(game)/play/control/page.tsx
+++ b/app/(game)/play/control/page.tsx
@@ -1,7 +1,70 @@
 'use client'
 
+import { useState } from 'react'
+
+import { useGame } from '@/contexts/GameContext'
+import { Button } from '@/components/ui/Button'
+import { Modal } from '@/components/ui/Modal'
 import { GameControlPanel } from '@/components/game/GameControlPanel'
 
+/**
+ * Página del moderador — panel de control del juego.
+ *
+ * Al cargar, detecta si hay una partida guardada en localStorage y
+ * muestra un prompt para que el moderador decida si continuar o reiniciar.
+ */
 export default function ControlPage(): React.ReactElement {
-  return <GameControlPanel />
+  const { hasSavedGame, restoreSavedGame, dispatch } = useGame()
+  const [dismissed, setDismissed] = useState(false)
+
+  const showPrompt = hasSavedGame && !dismissed
+
+  const handleContinue = (): void => {
+    restoreSavedGame()
+    setDismissed(true)
+  }
+
+  const handleNewGame = (): void => {
+    dispatch({ type: 'RESET_GAME' })
+    setDismissed(true)
+  }
+
+  return (
+    <>
+      <GameControlPanel />
+
+      {/* ── Modal: continuar partida guardada ───────────────────────────── */}
+      <Modal
+        isOpen={showPrompt}
+        onClose={handleNewGame}
+        title="Continuar partida"
+        dismissible={false}
+        footer={
+          <div className="flex gap-3 w-full justify-end">
+            <Button
+              variant="outline"
+              onClick={handleNewGame}
+              ariaLabel="Iniciar nuevo juego"
+            >
+              Nuevo juego
+            </Button>
+            <Button
+              variant="primary"
+              onClick={handleContinue}
+              ariaLabel="Continuar partida guardada"
+            >
+              Sí, continuar
+            </Button>
+          </div>
+        }
+      >
+        <p className="text-gray-300 text-sm leading-relaxed">
+          Se encontró una partida guardada. ¿Deseas continuar desde donde la dejaste?
+        </p>
+        <p className="text-gray-500 text-xs mt-2">
+          Selecciona <strong className="text-gray-400">Nuevo juego</strong> para descartarla e iniciar desde cero.
+        </p>
+      </Modal>
+    </>
+  )
 }

--- a/components/game/GameControlPanel.tsx
+++ b/components/game/GameControlPanel.tsx
@@ -259,6 +259,12 @@ export function GameControlPanel(): React.ReactElement {
             Engine: Activo
           </span>
           <span>Fase: {state.phase}</span>
+          {state.phase !== 'setup' && (
+            <span className="flex items-center gap-1 text-green-500/60">
+              <span className="material-symbols-outlined text-[10px] leading-none">save</span>
+              Auto-guardado
+            </span>
+          )}
         </div>
         <span className="text-primary font-bold">La Respuesta más Popular</span>
       </footer>

--- a/contexts/GameContext.tsx
+++ b/contexts/GameContext.tsx
@@ -6,6 +6,12 @@
  * El reducer delega cada acción al gameEngine puro, garantizando que
  * toda la lógica de negocio esté centralizada y sin efectos secundarios.
  *
+ * Persistencia (solo desde /play/control):
+ * - Auto-guarda en localStorage cada vez que el estado cambia (phase !== 'setup')
+ * - Al montar, detecta si hay una partida guardada y expone `hasSavedGame`
+ * - `restoreSavedGame()` restaura el estado completo guardado
+ * - `RESET_GAME` sin payload limpia el estado guardado de localStorage
+ *
  * Uso básico:
  *   // En una página de juego:
  *   <GameProvider>
@@ -17,10 +23,11 @@
  *   dispatch({ type: 'REVEAL_ANSWER', payload: 0 })
  */
 
-import { createContext, useContext, useEffect, useReducer, useRef } from 'react'
+import { createContext, useCallback, useContext, useEffect, useReducer, useRef, useState } from 'react'
 
 import { GAME_CHANNEL_NAME, type GameChannelMessage } from '@/lib/game/broadcastChannel'
 import { gameEngine } from '@/lib/game/gameEngine'
+import { localStorageAdapter } from '@/lib/storage/localStorage'
 import type { GameAction, GameState } from '@/types/game.types'
 
 // ─── Estado inicial ──────────────────────────────────────────────────────────
@@ -76,6 +83,9 @@ function gameReducer(state: GameState, action: GameAction): GameState {
         ? gameEngine.createGame(action.payload)
         : initialState
 
+    case 'RESTORE_GAME':
+      return action.payload
+
     default:
       return state
   }
@@ -86,6 +96,10 @@ function gameReducer(state: GameState, action: GameAction): GameState {
 interface GameContextType {
   state: GameState
   dispatch: React.Dispatch<GameAction>
+  /** Indica si existe una partida guardada en localStorage pendiente de restaurar */
+  hasSavedGame: boolean
+  /** Restaura el estado completo desde localStorage y cierra el prompt */
+  restoreSavedGame: () => void
 }
 
 const GameContext = createContext<GameContextType | undefined>(undefined)
@@ -107,8 +121,21 @@ const GameContext = createContext<GameContextType | undefined>(undefined)
  * ```
  */
 export function GameProvider({ children }: { children: React.ReactNode }) {
-  const [state, dispatch] = useReducer(gameReducer, initialState)
+  const [state, baseDispatch] = useReducer(gameReducer, initialState)
   const channelRef = useRef<BroadcastChannel | null>(null)
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Partida guardada detectada al montar. Lazy initializer: lee localStorage
+  // una sola vez en el cliente; retorna null en SSR para evitar mismatch.
+  const [savedGame, setSavedGame] = useState<GameState | null>(() => {
+    if (typeof window === 'undefined') return null
+    const saved = localStorageAdapter.getCurrentGame()
+    return saved && saved.phase !== 'setup' ? saved : null
+  })
+
+  const hasSavedGame = savedGame !== null
+
+  // ── BroadcastChannel ──────────────────────────────────────────────────────
 
   // Open channel once on mount, close on unmount
   useEffect(() => {
@@ -126,7 +153,52 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
     channelRef.current?.postMessage(message)
   }, [state])
 
-  return <GameContext.Provider value={{ state, dispatch }}>{children}</GameContext.Provider>
+  // ── Persistencia localStorage ─────────────────────────────────────────────
+
+  // Auto-guardar con debounce de 1 s cuando el juego está activo
+  useEffect(() => {
+    if (state.phase === 'setup') return
+
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
+    saveTimerRef.current = setTimeout(() => {
+      localStorageAdapter.saveCurrentGame(state)
+    }, 1000)
+
+    return () => {
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
+    }
+  }, [state])
+
+  // ── Dispatch envuelto ─────────────────────────────────────────────────────
+
+  /**
+   * Dispatch que intercepta `RESET_GAME` sin payload para limpiar localStorage.
+   */
+  const dispatch: React.Dispatch<GameAction> = useCallback(
+    (action) => {
+      if (action.type === 'RESET_GAME' && !action.payload) {
+        localStorageAdapter.clearCurrentGame()
+      }
+      baseDispatch(action)
+    },
+    []
+  )
+
+  // ── restoreSavedGame ──────────────────────────────────────────────────────
+
+  const restoreSavedGame = useCallback((): void => {
+    if (!savedGame) return
+    baseDispatch({ type: 'RESTORE_GAME', payload: savedGame })
+    setSavedGame(null)
+  }, [savedGame])
+
+  // ─────────────────────────────────────────────────────────────────────────
+
+  return (
+    <GameContext.Provider value={{ state, dispatch, hasSavedGame, restoreSavedGame }}>
+      {children}
+    </GameContext.Provider>
+  )
 }
 
 // ─── Hook ────────────────────────────────────────────────────────────────────

--- a/types/game.types.ts
+++ b/types/game.types.ts
@@ -104,3 +104,4 @@ export type GameAction =
   | { type: 'NEXT_QUESTION' }
   | { type: 'END_GAME' }
   | { type: 'RESET_GAME'; payload?: GameConfig }
+  | { type: 'RESTORE_GAME'; payload: GameState }


### PR DESCRIPTION
## Summary

Implements game state persistence in localStorage as described in #29.

## Changes

- **`types/game.types.ts`** — adds `RESTORE_GAME` action (`payload: GameState`) to `GameAction` union
- **`contexts/GameContext.tsx`** — full persistence layer:
  - Lazy `useState` initializer reads `localStorage` on mount (SSR-safe, no hydration mismatch, no setState-in-effect)
  - Auto-saves state with 1 s debounce when `phase !== 'setup'`
  - Wrapped `dispatch` clears `localStorage` on `RESET_GAME` without payload
  - Exposes `hasSavedGame: boolean` and `restoreSavedGame()` via context
- **`app/(game)/play/control/page.tsx`** — shows a "¿Continuar partida?" `Modal` on load when `hasSavedGame` is true; user chooses to restore or start a new game
- **`components/game/GameControlPanel.tsx`** — "Auto-guardado" indicator in footer when game is active

## Flow

1. Moderator plays → state auto-saved every ~1 s
2. Moderator reloads `/play/control` → modal appears
3. **Continuar** → full state restored, board syncs via BroadcastChannel
4. **Nuevo juego** → `RESET_GAME` dispatched, localStorage cleared

## Testing

- [x] TypeScript: 0 errors (`npx tsc --noEmit`)
- [x] Lint: 0 errors (`npm run lint`)
- [x] No setState-in-effect (uses lazy initializer)
- [x] SSR-safe (`typeof window === 'undefined'` guard)
- [x] `/play/board` has zero persistence logic — read-only via BroadcastChannel

## Related Issues

Closes #29

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)