### PR TITLE
feat: save completed games to Supabase (#50)

### DIFF
--- a/app/(game)/play/control/page.tsx
+++ b/app/(game)/play/control/page.tsx
@@ -14,7 +14,7 @@ import { GameControlPanel } from '@/components/game/GameControlPanel'
  * muestra un prompt para que el moderador decida si continuar o reiniciar.
  */
 export default function ControlPage(): React.ReactElement {
-  const { hasSavedGame, restoreSavedGame, dispatch } = useGame()
+  const { hasSavedGame, restoreSavedGame, dispatch, gameSaveState } = useGame()
   const [dismissed, setDismissed] = useState(false)
 
   const showPrompt = hasSavedGame && !dismissed
@@ -32,6 +32,28 @@ export default function ControlPage(): React.ReactElement {
   return (
     <>
       <GameControlPanel />
+
+      {/* ── Banner: estado del guardado de la partida ────────────────────── */}
+      {gameSaveState === 'saving' && (
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-2 px-5 py-3 rounded-xl bg-game-card border border-warm-border shadow-lg text-sm text-gray-300">
+          <span className="material-symbols-outlined text-primary text-base animate-spin leading-none">progress_activity</span>
+          Guardando partida…
+        </div>
+      )}
+
+      {gameSaveState === 'saved' && (
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-2 px-5 py-3 rounded-xl bg-game-card border border-success/40 shadow-lg text-sm text-success">
+          <span className="material-symbols-outlined text-base leading-none">check_circle</span>
+          Partida guardada en el historial
+        </div>
+      )}
+
+      {gameSaveState === 'error' && (
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-2 px-5 py-3 rounded-xl bg-game-card border border-danger-strike/40 shadow-lg text-sm text-danger-strike">
+          <span className="material-symbols-outlined text-base leading-none">error</span>
+          No se pudo guardar la partida
+        </div>
+      )}
 
       {/* ── Modal: continuar partida guardada ───────────────────────────── */}
       <Modal

--- a/app/(game)/play/page.tsx
+++ b/app/(game)/play/page.tsx
@@ -43,6 +43,7 @@ export default function PlaySetupPage(): React.ReactElement {
       team2Name: team2Name.trim() || 'Equipo 2',
       totalRounds: Math.min(totalRounds, maxRounds),
       questions: selectedSet.questions,
+      questionSetId: selectedSetId,
     }
     dispatch({ type: 'RESET_GAME', payload: config })
 

--- a/contexts/GameContext.tsx
+++ b/contexts/GameContext.tsx
@@ -28,7 +28,9 @@ import { createContext, useCallback, useContext, useEffect, useReducer, useRef, 
 import { GAME_CHANNEL_NAME, type GameChannelMessage } from '@/lib/game/broadcastChannel'
 import { gameEngine } from '@/lib/game/gameEngine'
 import { localStorageAdapter } from '@/lib/storage/localStorage'
-import type { GameAction, GameState } from '@/types/game.types'
+import { getStorageAdapter } from '@/lib/storage/storageManager'
+import { useAuth } from '@/contexts/AuthContext'
+import type { GameAction, GameResult, GameState, Team } from '@/types/game.types'
 
 // ─── Estado inicial ──────────────────────────────────────────────────────────
 
@@ -100,6 +102,8 @@ interface GameContextType {
   hasSavedGame: boolean
   /** Restaura el estado completo desde localStorage y cierra el prompt */
   restoreSavedGame: () => void
+  /** Estado del guardado de la partida finalizada */
+  gameSaveState: 'idle' | 'saving' | 'saved' | 'error'
 }
 
 const GameContext = createContext<GameContextType | undefined>(undefined)
@@ -124,6 +128,17 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
   const [state, baseDispatch] = useReducer(gameReducer, initialState)
   const channelRef = useRef<BroadcastChannel | null>(null)
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // ── Auth ────────────────────────────────────────────────────────────────────
+  const { user } = useAuth()
+  // Ref to access current user inside async callbacks without stale closure
+  const userRef = useRef(user)
+  useEffect(() => { userRef.current = user }, [user])
+
+  // ── Game save state ─────────────────────────────────────────────────────────
+  const [gameSaveState, setGameSaveState] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
+  const startedAtRef = useRef<string | null>(null)
+  const savedGameIdRef = useRef<string | null>(null)
 
   // Partida guardada detectada al montar. Lazy initializer: lee localStorage
   // una sola vez en el cliente; retorna null en SSR para evitar mismatch.
@@ -169,15 +184,66 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
     }
   }, [state])
 
+  // ── Persistencia en Supabase al finalizar ─────────────────────────────────
+
+  // Track game start time: record once (via ref only) when phase first leaves 'setup'
+  useEffect(() => {
+    if (state.phase === 'setup') {
+      startedAtRef.current = null
+    } else if (!startedAtRef.current) {
+      startedAtRef.current = new Date().toISOString()
+    }
+  }, [state.phase])
+
+  // Save completed game to storage (Supabase if authenticated, localStorage otherwise)
+  useEffect(() => {
+    if (state.phase !== 'finished') return
+    if (savedGameIdRef.current === state.id) return // already saved
+
+    savedGameIdRef.current = state.id
+
+    const completedAt = new Date().toISOString()
+    const winner: Team | 'draw' =
+      state.team1.score > state.team2.score ? 'team1'
+      : state.team2.score > state.team1.score ? 'team2'
+      : 'draw'
+
+    const result: GameResult = {
+      id: state.id,
+      team1: state.team1,
+      team2: state.team2,
+      winner,
+      totalRounds: state.totalRounds,
+      completedAt,
+      questionSetId: state.questionSetId,
+    }
+
+    const currentUser = userRef.current
+    const adapter = getStorageAdapter(currentUser)
+
+    Promise.resolve(adapter.saveGameHistory(result, currentUser?.id))
+      .then(() => {
+        localStorageAdapter.clearCurrentGame()
+        setGameSaveState('saved')
+      })
+      .catch(() => {
+        setGameSaveState('error')
+      })
+  }, [state.phase, state.id]) // eslint-disable-line react-hooks/exhaustive-deps
+
   // ── Dispatch envuelto ─────────────────────────────────────────────────────
 
   /**
-   * Dispatch que intercepta `RESET_GAME` sin payload para limpiar localStorage.
+   * Dispatch que intercepta `RESET_GAME` para limpiar localStorage y
+   * reiniciar el estado de guardado.
    */
   const dispatch: React.Dispatch<GameAction> = useCallback(
     (action) => {
-      if (action.type === 'RESET_GAME' && !action.payload) {
+      if (action.type === 'RESET_GAME') {
         localStorageAdapter.clearCurrentGame()
+        startedAtRef.current = null
+        savedGameIdRef.current = null
+        setGameSaveState('idle')
       }
       baseDispatch(action)
     },
@@ -195,7 +261,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
   // ─────────────────────────────────────────────────────────────────────────
 
   return (
-    <GameContext.Provider value={{ state, dispatch, hasSavedGame, restoreSavedGame }}>
+    <GameContext.Provider value={{ state, dispatch, hasSavedGame, restoreSavedGame, gameSaveState }}>
       {children}
     </GameContext.Provider>
   )

--- a/lib/game/gameEngine.ts
+++ b/lib/game/gameEngine.ts
@@ -85,6 +85,7 @@ export const gameEngine = {
       roundPoints: 0,
       multiplier: 1,
       questions: config.questions,
+      questionSetId: config.questionSetId,
     }
   },
 

--- a/types/game.types.ts
+++ b/types/game.types.ts
@@ -62,6 +62,8 @@ export interface GameState {
   multiplier: number
   /** Lista de preguntas de la partida */
   questions: Question[]
+  /** ID del set de preguntas usado (opcional para sets de demo) */
+  questionSetId?: string
 }
 
 /**
@@ -77,6 +79,8 @@ export interface GameConfig {
   totalRounds: number
   /** Preguntas que se jugarán */
   questions: Question[]
+  /** ID del set de preguntas seleccionado (opcional para sets de demo) */
+  questionSetId?: string
 }
 
 /** Resultado de una partida completada, listo para persistir */
@@ -87,8 +91,8 @@ export interface GameResult {
   winner: Team | 'draw'
   totalRounds: number
   completedAt: string
-  /** ID del set de preguntas usado */
-  questionSetId: string
+  /** ID del set de preguntas usado (opcional para sets de demo) */
+  questionSetId?: string
 }
 
 // ─── Acciones del reducer ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Implements functionality described in #50

## Changes
- Added `questionSetId` to `GameConfig` and `GameState` so the selected set is tracked through the whole game lifecycle
- Made `GameResult.questionSetId` optional to support demo sets (no DB ID)
- Updated `gameEngine.createGame()` to propagate `questionSetId` from config
- Passed `questionSetId` from the play setup page (`/play`) when launching
- Modified `GameContext` to detect `phase === 'finished'` and automatically save via the storage adapter (Supabase if authenticated, localStorage otherwise)
- Exposed `gameSaveState` (`'idle' | 'saving' | 'saved' | 'error'`) in context
- Added save confirmation/error banner in `/play/control` when the game ends

## Testing
- [x] Code follows CLAUDE.md conventions
- [x] `npx tsc --noEmit` — no errors
- [x] `npm run lint` — no errors (only pre-existing warnings)
- [x] `npx next build` — clean build, all pages compile
- [x] No console errors
- [x] Responsive design not affected (banner is fixed-positioned overlay)

## Screenshots (if applicable)
Test flow: `/play` → configure teams + select set → launch → play through all questions → observe save banner at bottom of `/play/control` when game finishes

## Related Issues
Closes #50

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)